### PR TITLE
Bugfix for nexted rules returning sentinels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,5 +6,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@1.0.0
-      - uses: excitedleigh/setup-nox@0.1.0
+      - uses: excitedleigh/setup-nox@v2.0.0
       - run: nox

--- a/bridgekeeper/rule_r_tests.py
+++ b/bridgekeeper/rule_r_tests.py
@@ -1,8 +1,11 @@
+from django.db.models import Q
+
 import pytest
+
 from shrubberies.factories import ShrubberyFactory, StoreFactory, UserFactory
 from shrubberies.models import Shrubbery, Store
 
-from .rules import R
+from .rules import EMPTY, R, UNIVERSAL, Rule
 
 pytestmark = pytest.mark.django_db
 
@@ -126,3 +129,74 @@ def test_many_relation_to_user():
     assert qs2.count() == 1
     assert s2 in qs2
     assert s1 not in qs2
+
+
+def test_sentinels_with_single_R_kwarg():
+    class TestBranchRule(Rule):
+        """A rule that allows superusers to see all branches, staff to see
+        nothing, and other users to see their own.
+        """
+        def query(self, user):
+            if user.is_superuser:
+                return UNIVERSAL
+            elif user.is_staff:
+                return EMPTY
+            else:
+                return Q(profile__user=user)
+
+        def check(self, user, instance=None):
+            if instance is None:
+                return False
+            
+            if user.is_superuser:
+                return True
+            elif user.is_staff:
+                return False
+            else:
+                return user.profile.branch == instance
+
+    # Create 2 users with their own branches
+    u1 = UserFactory()
+    u2 = UserFactory()
+    s1 = ShrubberyFactory(branch=u1.profile.branch)
+    s2 = ShrubberyFactory(branch=u2.profile.branch)
+    
+    # Create superuser/staff
+    superuser = UserFactory(is_superuser=True)
+    staff = UserFactory(is_staff=True)
+
+    # Create R rule
+    belongs_to_branch_r = R(branch=TestBranchRule())
+
+    # Test users can only see their own
+    assert belongs_to_branch_r.check(u1, s1)
+    assert belongs_to_branch_r.check(u2, s2)
+    assert not belongs_to_branch_r.check(u1, s2)
+    assert not belongs_to_branch_r.check(u2, s1)
+
+    # Test superuser can see all and staff see none
+    assert belongs_to_branch_r.check(superuser, s1)
+    assert belongs_to_branch_r.check(superuser, s2)
+    assert not belongs_to_branch_r.check(staff, s2)
+    assert not belongs_to_branch_r.check(staff, s1)
+
+    # Check queryset filtering results in the same behaviour for users
+    qs1_r = belongs_to_branch_r.filter(u1, Shrubbery.objects.all())
+    qs2_r = belongs_to_branch_r.filter(u2, Shrubbery.objects.all())
+    assert qs1_r.count() == 1
+    assert s1 in qs1_r
+    assert s2 not in qs1_r
+    assert qs2_r.count() == 1
+    assert s2 in qs2_r
+    assert s1 not in qs2_r
+
+    # Check queryset filtering results in the same behaviour for superusers
+    # and staff
+    qs_super_r = belongs_to_branch_r.filter(superuser, Shrubbery.objects.all())
+    qs_staff_r = belongs_to_branch_r.filter(staff, Shrubbery.objects.all())
+    assert qs_super_r.count() == 2
+    assert s1 in qs_super_r
+    assert s2 in qs_super_r
+    assert qs_staff_r.count() == 0
+    assert s2 not in qs_staff_r
+    assert s1 not in qs_staff_r

--- a/bridgekeeper/rules.py
+++ b/bridgekeeper/rules.py
@@ -359,10 +359,17 @@ class R(Rule):
             # TODO: check lookups are not being used
             if isinstance(value, Rule):
                 child_q_obj = value.query(user)
+                if child_q_obj is EMPTY:
+                    return EMPTY
+                elif child_q_obj is UNIVERSAL:
+                    child_q_obj = Q()
                 accumulated_q &= add_prefix(child_q_obj, key)
             else:
                 resolved_value = value(user) if callable(value) else value
                 accumulated_q &= Q(**{key: resolved_value})
+
+        if accumulated_q == Q():
+            return UNIVERSAL
 
         return accumulated_q
 


### PR DESCRIPTION
Using an `R` rule with a nested `Rule` that returned a `Sentinel` resulted in an unexpected exception. This was due to the lack of handling of sentinels by `R.query()`. This has been addressed by, checking the result of the nested `R.query` and:
* returning the `EMPTY` sentinel without further processing of the `R` rule if a nested rule returns `EMPTY`,
* replacing the `UNIVERSAL` sentinel with an empty `Q` and returning the `UNIVERSAL` sentinel if the accumulated `Q` is empty.

This ensures `R` is compliant with the both the expected return value of nested rules, and returns the expected result (using sentinels where appropriate) as used by the DRF `RulePermission` class and `Rule.filter()` method.