### PR TITLE
Use `filter()` for `Rule.check()` instead of trying to emulate the Django ORM

### DIFF
--- a/bridgekeeper/rule_r_tests.py
+++ b/bridgekeeper/rule_r_tests.py
@@ -170,7 +170,6 @@ def test_sentinels_with_single_R_kwarg():
         def check(self, user, instance=None):
             if instance is None:
                 return False
-            
             if user.is_superuser:
                 return True
             elif user.is_staff:
@@ -183,7 +182,7 @@ def test_sentinels_with_single_R_kwarg():
     u2 = UserFactory()
     s1 = ShrubberyFactory(branch=u1.profile.branch)
     s2 = ShrubberyFactory(branch=u2.profile.branch)
-    
+
     # Create superuser/staff
     superuser = UserFactory(is_superuser=True)
     staff = UserFactory(is_staff=True)

--- a/bridgekeeper/rules.py
+++ b/bridgekeeper/rules.py
@@ -122,7 +122,13 @@ class Rule:
         this rule for a given instance, or if none is provided,
         every instance.
         """
-        if instance is None:
+        # If an instance context was not given, we could only possibly return
+        # True if the rule universally passes for the user.
+        if self.query(user) is UNIVERSAL:
+            return True
+        elif instance is None:
+            # An instance context was not given, and the rule does not
+            # universally pass. We must return false.
             return False
         # Get a queryset with only this instance in it
         queryset = instance._meta.model.objects.filter(pk=instance.pk)
@@ -248,9 +254,6 @@ class blanket_rule(Rule):  # noqa: used as a decorator, so should be lowercase
 
     def query(self, user):
         return UNIVERSAL if self.rule_func(user) else EMPTY
-
-    def check(self, user, instance=None):
-        return self.rule_func(user)
 
 
 @blanket_rule

--- a/bridgekeeper/rules.py
+++ b/bridgekeeper/rules.py
@@ -128,13 +128,16 @@ class Rule:
         this with more optimised single-instance check logic (if it makes sense
         in your use case).
         """
-        # If an instance context was not given, we could only possibly return
-        # True if the rule universally passes for the user.
-        if self.query(user) is UNIVERSAL:
+        query_result = self.query(user)
+        if query_result is UNIVERSAL:
+            # This rule universally passes for this user.
             return True
+        elif query_result is EMPTY:
+            # This rule universally fails for this user.
+            return False
         elif instance is None:
-            # An instance context was not given, and the rule does not
-            # universally pass. We must return false.
+            # An instance context was not given and no blanket pass/fail
+            # applied, so the rule must fail.
             return False
         # Get a queryset with only this instance in it
         queryset = instance._meta.model.objects.filter(pk=instance.pk)

--- a/bridgekeeper/rules.py
+++ b/bridgekeeper/rules.py
@@ -121,6 +121,12 @@ class Rule:
         Given a user, return a boolean indicating if that user satisfies
         this rule for a given instance, or if none is provided,
         every instance.
+
+        By default, this method checks the provided instance against the
+        QuerySet provided by :meth:`filter`, however this necessitates a
+        database call for every :meth:`check` call, so you may wish to override
+        this with more optimised single-instance check logic (if it makes sense
+        in your use case).
         """
         # If an instance context was not given, we could only possibly return
         # True if the rule universally passes for the user.


### PR DESCRIPTION
This is a large deviation from how upstream Bridgekeeper works, and is justified on the premise that `check()` can never accurately/reliably emulate the Django ORM, which is what Bridgekeeper attempts to achieve by promising `Rule`-consistent behaviour between `check()` (single instance) and `filter()` (filtering a `QuerySet`). For example, `R.check()` does not handle traversing relationships in a way that is consistent with `filter()`.

With this PR, we move to having `check()` call `filter()` under the hood. It pre-filters the `QuerySet` so that it only contains the provided instance, and returns whether or not the `QuerySet` contains any records (i.e. `QuerySet.exists()`).

This is an initial implementation that passes al of the current tests. At a minimum, documentation still needs to be updated. I also believe that there are a lot of unit tests that are no longer relevant as they're all checking what is now a single implementation of `check()`. It may be worth keeping around them for now.

I also had to leave the current implementation of  `blanket_rule.check()` in order for a blanket rule test to pass. I think that this is expected given the nature of `blanket_rule()` (i.e. it doesn't take an instance context, only a user context, so a discriminating `filter()` doesn't make sense at all). As such, `blanket_rule.query()` simply returns `UNIVERSAL` or `EMPTY` depending on whether or not the rule function returns `True` or `False`. Since the (new) base implementation of `Rule.check()` always returns `False` if an instance is not provided, the base implementation needs to be sidestepped in situations where an instance is not provided...which I think only happens with blanket rules?