### PR TITLE
Updated `Rule.check()` to only pull the `pk` from the database as par…

### DIFF
--- a/bridgekeeper/rules.py
+++ b/bridgekeeper/rules.py
@@ -144,7 +144,7 @@ class Rule:
         # Filter the queryset by the Rule
         queryset = self.filter(user, queryset)
         # Check if it exists
-        return queryset.exists()
+        return queryset.only("pk").exists()
 
     def __and__(self, other):
         return And(self, other)


### PR DESCRIPTION
…t of the `exists()` check

From what I can tell, `exists()` queries still select all columns from the database as part of the query. This slows down the query. Some very rudimentary tests outside of bridgekeeper suggest this can be as much as a factor of 2.